### PR TITLE
copy project directory structure to temporary directory

### DIFF
--- a/lbuild
+++ b/lbuild
@@ -22,6 +22,7 @@ def main():
 
     sys.exit(0)
 
+
 def real_main():
     parser = argparse.ArgumentParser(description='Building LaTeX documents')
     parser.add_argument('texpath', type=str, help='Path to tex file')
@@ -33,6 +34,7 @@ def real_main():
 
     process(args.texpath, args.latex_engine, args.timeout)
 
+
 def process(tex, engine, timeout):
     assert path.isfile(tex)
     assert tex.endswith(".tex")
@@ -42,7 +44,17 @@ def process(tex, engine, timeout):
 
     assert engine in ["lualatex", "pdflatex", "xelatex"]
 
-    with TemporaryDirectory(prefix="lmake-", suffix="-tmp") as tmp:
+    with TemporaryDirectory(prefix="lbuild-", suffix="-outTmp") as tmp:
+        shutil.rmtree(tmp)
+        # Inspired by http://stackoverflow.com/a/35118551
+        # Copies the directory structure but not the files itself in order to compile included files in subdirectories
+        shutil.copytree(os.path.dirname(tex), tmp, copy_function=shutil.copy,
+                        ignore=lambda x, y: [r for r in y if os.path.isfile(x + os.sep + r)])
+
+        if not path.isfile(tex):
+            print("Given tex path is no file!")
+            raise InvalidArgumentException()
+
         cmd = [
             "latexmk",
             "-cd",


### PR DESCRIPTION
copy project directory structure to temporary directory by default in order to be able to compile project with included files in subdirectories